### PR TITLE
Remove xtrace output from the logging methods

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -18,12 +18,12 @@ main(){
 	the function output, the "echo"
 	'
 	include logger.Logger
-	debug()   { ( Logger log debug "${@}" ) }
-	info()    { ( Logger log info "${@}" ) }
-	warning() { ( Logger log warning "${@}" ) }
-	error()   { ( Logger log error "${@}" ) }
-	success() { ( Logger log success "${@}" ) }
-	fatal()   { ( Logger log fatal "${@}" ) }
+	debug()   { ( set +x; Logger log debug "${@}" ) }
+	info()    { ( set +x; Logger log info "${@}" ) }
+	warning() { ( set +x; Logger log warning "${@}" ) }
+	error()   { ( set +x; Logger log error "${@}" ) }
+	success() { ( set +x; Logger log success "${@}" ) }
+	fatal()   { ( set +x; Logger log fatal "${@}" ) }
 }
 
 main


### PR DESCRIPTION
On using the --debug, there is too much output because the logging statements are themselves being traced.

Remove this tracing and allow all the rest to be displayed.